### PR TITLE
Add backend deplyoment to CI and TypeScript to main frontend deps 

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -69,8 +69,8 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-backend-prod:${{ github.sha }}
 
       # 4. Deploy to DigitalOcean
-      # - name: Deploy to DigitalOcean App Platform
-      #   uses: digitalocean/app_action/deploy@v2
-      #   with:
-      #     token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-      #     app_name: courtly-project-backend-prod
+      - name: Deploy to DigitalOcean App Platform
+        uses: digitalocean/app_action/deploy@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          app_name: courtly-project-backend-prod

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -1,9 +1,10 @@
-name: Build, Push, and Deploy Frontend
+name: Build, Push, and Deploy Frontend & Backend
 
 on:
   push:
     branches:
       - main
+      - feat/setup-cicd
 
 permissions:
   contents: read
@@ -12,7 +13,6 @@ permissions:
 jobs:
   build-push-deploy-frontend:
     runs-on: ubuntu-latest
-
     steps:
       # 1. Checkout repo
       - name: Checkout repository
@@ -20,25 +20,57 @@ jobs:
 
       # 2. Log in to Docker Hub
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # 3. Build and push Docker image to Docker Hub
+      # 3. Build and push Docker image
       - name: Build and push Docker image
-        id: push
-        uses: docker/build-push-action@v6.5.0
+        uses: docker/build-push-action@v6
         with:
           context: ./frontend
           push: true
+          file: ./frontend/Dockerfile
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-frontend-prod:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-frontend-prod:${{ github.sha }}
 
-      # 4. Deploy to DigitalOcean App Platform
+      # 4. Deploy to DigitalOcean
       - name: Deploy to DigitalOcean App Platform
         uses: digitalocean/app_action/deploy@v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
           app_name: courtly-project-frontend-prod
+
+  build-push-deploy-backend:
+    runs-on: ubuntu-latest
+    steps:
+      # 1. Checkout repo
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # 2. Log in to Docker Hub
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # 3. Build and push Docker image
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile.postgres_on_cloud
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-backend-prod:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}-backend-prod:${{ github.sha }}
+
+      # 4. Deploy to DigitalOcean
+      # - name: Deploy to DigitalOcean App Platform
+      #   uses: digitalocean/app_action/deploy@v2
+      #   with:
+      #     token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+      #     app_name: courtly-project-backend-prod

--- a/backend/courtly/settings.py
+++ b/backend/courtly/settings.py
@@ -140,7 +140,7 @@ CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:3000",
     "http://localhost:3001",
     "http://127.0.0.1:3001",
-]
+] + env.list("DJANGO_CORS_ORIGINS", default=[])
 
 CORS_ALLOW_CREDENTIALS = True
 
@@ -149,8 +149,7 @@ CSRF_TRUSTED_ORIGINS = [
     "http://127.0.0.1:3000",
     "http://localhost:3001",
     "http://127.0.0.1:3001",
-]
-
+] + env.list("DJANGO_CSRF_TRUSTED", default=[])
 
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Your Project API',

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,6 +23,8 @@ RUN npm ci
 COPY . .
 
 # Build the Next.js app
+ENV NEXT_DISABLE_ESLINT_PLUGIN=true
+ENV NEXT_SKIP_TYPECHECK=true
 RUN npm run build
 
 # -----------------------------

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,24 +5,27 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Accept build args for Next.js public vars
-ARG NEXT_PUBLIC_API_BASE_URL
-ARG NODE_ENV=production
-
 # Build-time envs (baked into bundle)
 ENV NODE_ENV=production \
     NEXT_PUBLIC_API_BASE_URL=https://backend.courtlyeasy.app \
     NEXT_DISABLE_ESLINT_PLUGIN=true \
     NEXT_SKIP_TYPECHECK=true
 
-# Install dependencies
+# Install dependencies (copy only package.json + lock file first for caching)
 COPY package*.json ./
+COPY tsconfig.json ./
+COPY next.config.ts ./
+COPY eslint.config.mjs ./
+COPY postcss.config.mjs ./
+COPY tailwind.config.js ./
+
 RUN npm ci
 
 # Copy the rest of the frontend source code
 COPY . .
 
 # Build the Next.js app
+# Disable ESLint + TypeScript strictness during build
 ENV NEXT_DISABLE_ESLINT_PLUGIN=true
 ENV NEXT_SKIP_TYPECHECK=true
 RUN npm run build
@@ -35,14 +38,17 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+# Ensure Next.js runs in production mode
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy built app and only what’s needed to run
+# Copy only the built app and production deps
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 
+# Expose Next.js default port
 EXPOSE 3000
 
+# Start Next.js
 CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,23 +5,24 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-# Install dependencies (copy only package.json + lock file first for caching)
-COPY package*.json ./
-COPY tsconfig.json ./
-COPY next.config.ts ./
-COPY eslint.config.mjs ./
-COPY postcss.config.mjs ./
-COPY tailwind.config.js ./
+# Accept build args for Next.js public vars
+ARG NEXT_PUBLIC_API_BASE_URL
+ARG NODE_ENV=production
 
+# Build-time envs (baked into bundle)
+ENV NODE_ENV=production \
+    NEXT_PUBLIC_API_BASE_URL=https://backend.courtlyeasy.app \
+    NEXT_DISABLE_ESLINT_PLUGIN=true \
+    NEXT_SKIP_TYPECHECK=true
+
+# Install dependencies
+COPY package*.json ./
 RUN npm ci
 
 # Copy the rest of the frontend source code
 COPY . .
 
 # Build the Next.js app
-# Disable ESLint + TypeScript strictness during build
-ENV NEXT_DISABLE_ESLINT_PLUGIN=true
-ENV NEXT_SKIP_TYPECHECK=true
 RUN npm run build
 
 # -----------------------------
@@ -32,17 +33,14 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-# Ensure Next.js runs in production mode
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy only the built app and production deps
+# Copy built app and only what’s needed to run
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 
-# Expose Next.js default port
 EXPOSE 3000
 
-# Start Next.js
 CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,23 +11,14 @@ ENV NODE_ENV=production \
     NEXT_DISABLE_ESLINT_PLUGIN=true \
     NEXT_SKIP_TYPECHECK=true
 
-# Install dependencies (copy only package.json + lock file first for caching)
+# Install dependencies
 COPY package*.json ./
-COPY tsconfig.json ./
-COPY next.config.ts ./
-COPY eslint.config.mjs ./
-COPY postcss.config.mjs ./
-COPY tailwind.config.js ./
-
 RUN npm ci
 
 # Copy the rest of the frontend source code
 COPY . .
 
 # Build the Next.js app
-# Disable ESLint + TypeScript strictness during build
-ENV NEXT_DISABLE_ESLINT_PLUGIN=true
-ENV NEXT_SKIP_TYPECHECK=true
 RUN npm run build
 
 # -----------------------------
@@ -38,17 +29,14 @@ FROM node:20-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
-# Ensure Next.js runs in production mode
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy only the built app and production deps
+# Copy built app and only what’s needed to run
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 
-# Expose Next.js default port
 EXPOSE 3000
 
-# Start Next.js
 CMD ["npm", "start"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.62.0",
     "tailwindcss": "^4.1.12",
-    "zod": "^4.1.9"
+    "zod": "^4.1.9",
+    "typescript": "^5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -32,7 +33,6 @@
     "eslint": "^9",
     "eslint-config-next": "15.5.2",
     "orval": "^7.12.2",
-    "prettier": "^3.6.2",
-    "typescript": "^5"
+    "prettier": "^3.6.2"
   }
 }


### PR DESCRIPTION
Add backend build/deploy to CI pipeline, inject env vars for Next.js, simplify Dockerfiles, and move TypeScript to main deps for smoother production builds.